### PR TITLE
Find active record by model id

### DIFF
--- a/lib/rawscsi/search_helpers/results_active_record.rb
+++ b/lib/rawscsi/search_helpers/results_active_record.rb
@@ -7,7 +7,7 @@ module Rawscsi
       end
 
       def build
-        id_array = @response["hits"]["hit"].map {|h| h["id"].to_i }
+        id_array = @response["hits"]["hit"].map {|h| model_id(h["id"]) }
         return [] if id_array.empty?
         results =
           if ActiveRecord::VERSION::MAJOR > 2
@@ -21,6 +21,10 @@ module Rawscsi
       private
       def klass
         @model.constantize 
+      end
+
+      def model_id(doc_id)
+        doc_id.split('_').last.to_i
       end
     end
   end

--- a/rawscsi.gemspec
+++ b/rawscsi.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   unless RUBY_VERSION == "1.8.7"
     spec.add_development_dependency "activerecord", "> 2.0"
     spec.add_dependency "httparty", "~> 0.11"
-    spec.add_dependency "faraday", "0.9.0"
+    spec.add_dependency "faraday", "0.9.1"
     spec.add_dependency "faraday_middleware"
   else
     spec.add_development_dependency "activerecord", "2.0"


### PR DESCRIPTION
Since `"ModelName_12345".to_i` returns 0, `ResultsActiveRecord#build` always returns an empty array.