### PR TITLE
Make it possible to use scalar values in compound query

### DIFF
--- a/lib/rawscsi/query/compound.rb
+++ b/lib/rawscsi/query/compound.rb
@@ -71,9 +71,13 @@ module Rawscsi
         end
       end
 
-      def compound?(hash) 
-        ar = hash.keys
-        ar.include?(:and) || ar.include?(:or)
+      def compound?(value)
+        if value.kind_of?(Hash)
+          ar = value.keys
+          ar.include?(:and) || ar.include?(:or)
+        else
+          false
+        end
       end
 
       def stringify_compound(hash)
@@ -82,28 +86,37 @@ module Rawscsi
         "(#{bool_op}" + encode(" #{bool_map(ar)}") + ")"
       end
 
-      def stringify_noncompound(hash)
-        if not_hash = hash[:not]
+      def stringify_noncompound(value)
+        if value.kind_of?(Hash) && not_hash = value[:not]
           "(not" + encode(" #{stringify(not_hash)}") + ")"
-        elsif range = hash[:range]
+        elsif value.kind_of?(Hash) && range = value[:range]
           range 
         else
-          encode(stringify(hash))
+          encode(stringify(value))
         end
       end
 
-     def bool_map(array)
+     def bool_map(value)
         output = ""
-        array.each do |pred|
-          output << compound_bool(pred)
+        if value.kind_of?(Enumerable)
+          value.each do |v|
+            output << compound_bool(v)
+          end
+        else
+          output = compound_bool(value)
         end
+
         output
       end
 
-      def stringify(hash)
+      def stringify(value)
         output_str = ""
-        hash.each do |k,v|
-          output_str << "#{k}:'#{v}'"
+        if value.kind_of?(Hash)
+          value.each do |k,v|
+            output_str << "#{k}:'#{v}'"
+          end
+        else
+          output_str << value.to_s
         end
         output_str
       end

--- a/spec/lib/rawscsi/query/compound_spec.rb
+++ b/spec/lib/rawscsi/query/compound_spec.rb
@@ -86,5 +86,19 @@ describe Rawscsi::Query::Compound do
     str = Rawscsi::Query::Compound.new(arg).build
     expect(str).to eq("q=(and%20title:%27star%20wars%27)&start=2&size=3&q.parser=structured")
   end
+
+  it "constructs a prefix query" do
+    arg = {:q => "(prefix 'star wars')"}
+    str = Rawscsi::Query::Compound.new(arg).build
+    expect(str).to eq("q=(prefix%20%27star%20wars%27)&q.parser=structured")
+  end
+
+  it "constructs a combination of conjunction and prefix query" do
+    arg = {:q => {:and => [{:genres => "Action"},
+                           "(prefix field=actor 'Stallone')"]}}
+    str = Rawscsi::Query::Compound.new(arg).build
+
+    expect(str).to eq("q=(and%20genres:%27Action%27(prefix%20field=actor%20%27Stallone%27))&q.parser=structured")
+  end
 end
 


### PR DESCRIPTION
@StevenJL this is far from ideal, but at least enables me to tackle a problem at hand, namely build prefix search queries, as in http://git.io/NgMC

Thanks.