### PR TITLE
enable location search as the aws doc 

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,15 @@ search_songs.search(q: {and: [ {artist: "Cold Play"} ],
     { title: "Sparks"}]
 
 ```
+
+Search location(defined a location field with type latlon)
+
+```ruby
+User.search(q: {skills: 'boxing'},
+            sort: "distance asc",
+            "expr.distance": 'haversin(35.621966,-120.686706,location.latitude,location.longitude)')
+
+```
 The default sort order is Amazon Cloudsearch's rank-score but you can use your own sort as well as a limiting the number of results.
 ```ruby
 search_songs.search(q: {and: [{genres: "Rock"}]}, sort: "rating desc", limit: 100)

--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ User.search(q: {skills: 'boxing'},
             "expr.distance": 'haversin(35.621966,-120.686706,location.latitude,location.longitude)')
 
 ```
+
+For example, if you want matches within the title field to score higher than matches within the plot field, you could set the weight of the title field to 2 and the weight of the plot field to 0.5:
+
+```ruby
+Moive.search(q: {and: [{title: "title", plot: "plot"}]}, :'q.options' => "{fields:['title^2','plot^0.5']}")
+```
+
 The default sort order is Amazon Cloudsearch's rank-score but you can use your own sort as well as a limiting the number of results.
 ```ruby
 search_songs.search(q: {and: [{genres: "Rock"}]}, sort: "rating desc", limit: 100)

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ User.search(q: {skills: 'boxing'},
 For example, if you want matches within the title field to score higher than matches within the plot field, you could set the weight of the title field to 2 and the weight of the plot field to 0.5:
 
 ```ruby
-Moive.search(q: {and: [{title: "title", plot: "plot"}]}, :'q.options' => "{fields:['title^2','plot^0.5']}")
+Moive.search(q: {and: [{title: "title", plot: "plot"}]}, qoptions: "{fields:['title^2','plot^0.5']}")
 ```
 
 The default sort order is Amazon Cloudsearch's rank-score but you can use your own sort as well as a limiting the number of results.

--- a/lib/rawscsi/query/compound.rb
+++ b/lib/rawscsi/query/compound.rb
@@ -54,8 +54,8 @@ module Rawscsi
       end
 
       def qoptions
-        return nil unless query_hash[:'q.options']
-        "q.options=#{query_hash[:'q.options']}"
+        return nil unless query_hash[:qoptions]
+        "q.options=#{CGI.escape(query_hash[:qoptions])}"
       end
 
       def start

--- a/lib/rawscsi/query/compound.rb
+++ b/lib/rawscsi/query/compound.rb
@@ -11,6 +11,7 @@ module Rawscsi
       def build
         [
           query,
+          distance,
           date,
           sort,
           start,
@@ -46,11 +47,16 @@ module Rawscsi
         encode("sort=#{query_hash[:sort]}")
       end
 
+      def distance
+        return nil unless query_hash[:'expr.distance']
+        "expr.distance=#{query_hash[:'expr.distance']}"
+      end
+
       def start
         return nil unless query_hash[:start]
         "start=#{query_hash[:start]}"
       end
-     
+
       def limit
         return nil unless query_hash[:limit]
         "size=#{query_hash[:limit]}"

--- a/lib/rawscsi/query/compound.rb
+++ b/lib/rawscsi/query/compound.rb
@@ -12,6 +12,7 @@ module Rawscsi
         [
           query,
           distance,
+          qoptions,
           date,
           sort,
           start,
@@ -50,6 +51,11 @@ module Rawscsi
       def distance
         return nil unless query_hash[:'expr.distance']
         "expr.distance=#{query_hash[:'expr.distance']}"
+      end
+
+      def qoptions
+        return nil unless query_hash[:'q.options']
+        "q.options=#{query_hash[:'q.options']}"
       end
 
       def start

--- a/spec/lib/rawscsi/query/compound_spec.rb
+++ b/spec/lib/rawscsi/query/compound_spec.rb
@@ -9,11 +9,20 @@ describe Rawscsi::Query::Compound do
   end
 
   it "constructs a query that looks only at a single field and specifies fields" do
-    arg = {:q => {:and => [{:title => "star wars"}]}, :fields => [:title, :genres]}    
+    arg = {:q => {:and => [{:title => "star wars"}]}, :fields => [:title, :genres]}
     str = Rawscsi::Query::Compound.new(arg).build
     expect(str).to eq("q=(and%20title:%27star%20wars%27)&return=title,genres&q.parser=structured")
   end
 
+  it "constructs a query with distance" do
+    arg = { :q => { :and => [{:actors => "Arnold"}, {:title => "Terminator"},{:range => "rating:['8',}"}]},
+            :fields => [:title],
+            :'expr.distance' => "haversin(35.621966,-120.686706,location.latitude,location.longitude)"
+
+          }
+    str = Rawscsi::Query::Compound.new(arg).build
+    expect(str).to eq("q=(and%20actors:%27Arnold%27title:%27Terminator%27rating:%5B%278%27,%7D)&expr.distance=haversin(35.621966,-120.686706,location.latitude,location.longitude)&return=title&q.parser=structured")
+  end
   it "constructs a query with a numeric range" do
     arg = { :q => { :and => [{:actors => "Arnold"}, {:title => "Terminator"},{:range => "rating:['8',}"}]},
             :fields => [:title]
@@ -95,7 +104,7 @@ describe Rawscsi::Query::Compound do
 
   it "constructs a combination of conjunction and prefix query" do
     arg = {:q => {:and => [{:genres => "Action"},
-                           {:prefix => {:actor => "Stallone"}}]}} 
+                           {:prefix => {:actor => "Stallone"}}]}}
     str = Rawscsi::Query::Compound.new(arg).build
 
     expect(str).to eq("q=(and%20genres:%27Action%27(prefix%20field=actor%20%27Stallone%27))&q.parser=structured")

--- a/spec/lib/rawscsi/query/compound_spec.rb
+++ b/spec/lib/rawscsi/query/compound_spec.rb
@@ -23,6 +23,13 @@ describe Rawscsi::Query::Compound do
     str = Rawscsi::Query::Compound.new(arg).build
     expect(str).to eq("q=(and%20actors:%27Arnold%27title:%27Terminator%27rating:%5B%278%27,%7D)&expr.distance=haversin(35.621966,-120.686706,location.latitude,location.longitude)&return=title&q.parser=structured")
   end
+
+  it "constructs a query with q.options" do
+    arg = {:q => {:and => [{:title => "star wars"}]}, :fields => [:title, :genres], :'q.options' => "{fields:['title^2','genres^0.1']}"}
+    str = Rawscsi::Query::Compound.new(arg).build
+    expect(str).to eq("q=(and%20title:%27star%20wars%27)&q.options={fields:['title^2','genres^0.1']}&return=title,genres&q.parser=structured")
+  end
+
   it "constructs a query with a numeric range" do
     arg = { :q => { :and => [{:actors => "Arnold"}, {:title => "Terminator"},{:range => "rating:['8',}"}]},
             :fields => [:title]

--- a/spec/lib/rawscsi/query/compound_spec.rb
+++ b/spec/lib/rawscsi/query/compound_spec.rb
@@ -24,10 +24,10 @@ describe Rawscsi::Query::Compound do
     expect(str).to eq("q=(and%20actors:%27Arnold%27title:%27Terminator%27rating:%5B%278%27,%7D)&expr.distance=haversin(35.621966,-120.686706,location.latitude,location.longitude)&return=title&q.parser=structured")
   end
 
-  it "constructs a query with q.options" do
-    arg = {:q => {:and => [{:title => "star wars"}]}, :fields => [:title, :genres], :'q.options' => "{fields:['title^2','genres^0.1']}"}
+  it "constructs a query with qoptions" do
+    arg = {:q => {:and => [{:title => "star wars"}]}, :fields => [:title, :genres], qoptions: "{fields:['title^2','genres^0.1']}"}
     str = Rawscsi::Query::Compound.new(arg).build
-    expect(str).to eq("q=(and%20title:%27star%20wars%27)&q.options={fields:['title^2','genres^0.1']}&return=title,genres&q.parser=structured")
+    expect(str).to eq("q=(and%20title:%27star%20wars%27)&q.options=%7Bfields%3A%5B%27title%5E2%27%2C%27genres%5E0.1%27%5D%7D&return=title,genres&q.parser=structured")
   end
 
   it "constructs a query with a numeric range" do


### PR DESCRIPTION
Thanks for this client library, it would be great if it supports location search.

http://docs.aws.amazon.com/cloudsearch/latest/developerguide/searching-locations.html

