### PR TITLE
request signing implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ Rawscsi.register 'Book' do |config|
 end
 ```
 
+You can also specify AWS user credentials if you want to access the private serach domain.
+(note: search domain and AWS credentials specified below are fictional and serve only as an example) 
+
+```ruby
+Rawscsi.register 'SuperSecretDiaryEntry' do |config|
+  config.domain_name = 'super-secret-diary-entries'
+  config.domain_id = '12be09027f865cba2d57719'
+  config.region = 'us-east-1'
+  config.api_version = '2013-01-01' # rawscsi only supports api version 2013-01-01
+  config.access_key_id = '7386b16f9bee30d6e5a98786'
+  config.secret_key = 'af86958e6919a03713408fd9'
+end
+```
+
 ### Uploading indices
 ```ruby
 song_indexer = Rawscsi::Index.new('Song', :active_record => true)

--- a/README.md
+++ b/README.md
@@ -323,6 +323,18 @@ search_songs.search(q: {and: [{artist: "Beatles"}]},
                     limit: 5)
 ```
 
+## Request signing
+
+[Signature V4 guide from Amazon](http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html)
+
+Request signature is created by `Rawscsi::RequestSignature` class with simple public api with only a few methods:
+
++ `#initialize` - accepts the hash with the data of request to sign. 
+Required keys are `:secret_key`, `:access_key_id`, `:region_name`, `:endpoint`, `:method`, `:host`. 
+Optional keys are `:debug`, `:payload`, `:service_name`, `:headers`, `:query`.
+
++ `#build` - calculates and returns the hash with `:signature` key containing the headers to include in request.
+If `:debug` is passed on object creation, it also provides the debug data in `:debug` key, including of results of intermidiate steps.
 
 ## Contributing
 

--- a/lib/rawscsi.rb
+++ b/lib/rawscsi.rb
@@ -1,10 +1,11 @@
 $:.unshift(File.expand_path("../", __FILE__))
 
 module Rawscsi
-  autoload :VERSION,       'rawscsi/version'
-  autoload :Base,          'rawscsi/base'
-  autoload :Search,        'rawscsi/search'
-  autoload :Index,         'rawscsi/index'
+  autoload :VERSION,            'rawscsi/version'
+  autoload :Base,               'rawscsi/base'
+  autoload :RequestSignature,   'rawscsi/request_signature'
+  autoload :Search,             'rawscsi/search'
+  autoload :Index,              'rawscsi/index'
 
   module Query
     autoload :Simple,      "rawscsi/query/simple"
@@ -37,7 +38,12 @@ module Rawscsi
       :region,
       :api_version,
       :attributes,
-      :batch_size
+      :batch_size,
+      :use_https,
+      :access_key_id,
+      :secret_key,
+      :search_domain,
+      :index_domain
   end
   
   def self.register(model)

--- a/lib/rawscsi/index.rb
+++ b/lib/rawscsi/index.rb
@@ -52,6 +52,21 @@ module Rawscsi
         req.url "#{config.api_version}/documents/batch"
         req.headers["Content-type"] = "application/json"
         req.body = payload.to_json
+        if config.secret_key && config.access_key_id
+          signature = RequestSignature.new({
+            secret_key: config.secret_key,
+            access_key_id: config.access_key_id,
+            region_name: config.region,
+            endpoint: "/#{req.path}",
+            method: req.method.to_s.upcase,
+            headers: req.headers,
+            host: connection.url_prefix.hostname,
+            payload: req.body,
+          }).build
+          signature[:headers].each do |name, value|
+            req.headers[name] = value
+          end
+        end
       end
       resp.body
     end

--- a/lib/rawscsi/index_helpers/connection.rb
+++ b/lib/rawscsi/index_helpers/connection.rb
@@ -7,7 +7,7 @@ module Rawscsi
       attr_reader :url
       
       def initialize(config)
-        @url= "http://doc-#{config.domain_name}-#{config.domain_id}.#{config.region}.cloudsearch.amazonaws.com"
+        @url = config.index_domain || "http://doc-#{config.domain_name}-#{config.domain_id}.#{config.region}.cloudsearch.amazonaws.com"
       end
 
       def build

--- a/lib/rawscsi/request_signature.rb
+++ b/lib/rawscsi/request_signature.rb
@@ -1,0 +1,161 @@
+module Rawscsi
+  class RequestSignature
+    def initialize(*args)
+      options = args.extract_options!
+      required_attributes_missing = []
+      require_attribute = -> (name) do
+        return options[name] if options.has_key?(name) 
+        required_attributes_missing << name
+        nil 
+      end
+      
+      self.secret_key = require_attribute[:secret_key]
+      self.access_key_id = require_attribute[:access_key_id]
+      self.region_name = require_attribute[:region_name]
+      self.endpoint = require_attribute[:endpoint]
+      self.method = require_attribute[:method]
+      self.host = require_attribute[:host]
+
+      unless required_attributes_missing.size == 0
+        raise "#{required_attributes_missing.join(',')} attributes required for a request signature"
+      end
+    
+      self.debug_mode = options[:debug] || false  
+      self.payload = options[:payload] || ''
+      self.service_name = options[:service_name] || 'cloudsearch'
+      self.headers = options[:headers].to_h.merge(default_headers)
+      self.query = options[:query] || ''
+    end
+
+    def build
+      result_headers = default_headers.dup
+      result_headers['Authorization'] = "#{algo} Credential=#{access_key_id}/#{credential}, SignedHeaders=#{canonical_headers_names_string}, Signature=#{signature}"
+
+      result = { 
+        headers: result_headers, 
+      }
+
+      if debug_mode
+        result[:debug] = debug_data
+      end
+
+      result
+    end
+
+    private
+
+    def debug_data
+      {
+        canonical_request: canonical_request,
+        payload_digest: payload_digest,
+        canonical_request_digest: canonical_request_digest,
+        string_to_sign: string_to_sign,
+        signature: signature,
+        signed_headers: canonical_headers_names_string,
+        payload: payload,
+      }
+    end
+
+    attr_accessor :secret_key,
+      :access_key_id, 
+      :headers,
+      :payload,
+      :region_name, 
+      :service_name,
+      :method,
+      :endpoint,
+      :query,
+      :host,
+      :debug_mode
+
+    def signature 
+      OpenSSL::HMAC.hexdigest('sha256', signature_key, string_to_sign)
+    end
+    
+    def algo
+      'AWS4-HMAC-SHA256'
+    end
+
+    def default_headers
+      {
+        'X-Amz-Date' => amz_datetime,
+        'Host' => host,
+      }
+    end
+
+    def signature_key
+      k_date    = OpenSSL::HMAC.digest('sha256', "AWS4" + secret_key, date)
+      k_region  = OpenSSL::HMAC.digest('sha256', k_date, region_name)
+      k_service = OpenSSL::HMAC.digest('sha256', k_region, service_name)
+      k_signing = OpenSSL::HMAC.digest('sha256', k_service, "aws4_request")
+
+      k_signing
+    end
+
+    def datetime
+      @datetime ||= DateTime.now.utc
+    end
+
+    def amz_datetime
+      datetime.strftime('%Y%m%dT%H%M%SZ')
+    end
+
+    def date
+      datetime.strftime('%Y%m%d')
+    end
+
+    def credential
+      "#{date}/#{region_name}/cloudsearch/aws4_request"
+    end
+
+    def string_to_sign
+      [
+        algo,
+        amz_datetime,
+        credential,
+        canonical_request_digest,
+      ].join("\n")
+    end
+
+    def canonical_query_string
+      # @NOTE gsubs are here because AWS expects us to escape everything but #encode_www_form encodes space as "+"
+      @canonical_query_string = URI.encode_www_form(CGI::parse(query).to_a.sort { |a, b| a.first <=> b.first }).gsub('+', '%20').gsub('*', '%2A')
+    end
+
+    def canonical_headers_names_string
+      canonical_headers.map(&:first).join(';')
+    end
+
+    def canonical_headers
+      @canonical_headers ||= headers.to_a.group_by(&:first).map do |name, values|
+        canonical_values = values.map(&:last).map do |value|
+          value.to_s.first == '"' ? value : value.squeeze(' ')
+        end
+        [ name.to_s.downcase, canonical_values.join(',') ]
+      end.sort { |a, b| a.first <=> b.first }
+    end
+
+    def canonical_headers_string
+      canonical_headers.map { |header| header.join(':') }.join("\n") + "\n"
+    end
+
+    def payload_digest
+      @payload_digest ||= OpenSSL::Digest::SHA256.hexdigest(payload) 
+    end
+
+    def canonical_request
+      @canonical_request ||= [ 
+        method,
+        endpoint,
+        canonical_query_string,
+        canonical_headers_string,
+        canonical_headers_names_string,
+        payload_digest,
+      ].join("\n")
+    end
+
+    def canonical_request_digest
+      @canonical_request_digest ||= OpenSSL::Digest::SHA256.hexdigest(canonical_request)
+    end
+  end
+end

--- a/lib/rawscsi/search.rb
+++ b/lib/rawscsi/search.rb
@@ -24,23 +24,48 @@ module Rawscsi
     end
 
     private
+    def url_schema
+      config.use_https ? 'https' : 'http'
+    end
+
+    def canonical_url
+      "/#{config.api_version}/search"
+    end
+
+    def search_domain
+      config.search_domain || "search-#{config.domain_name}-#{config.domain_id}.#{config.region}.cloudsearch.amazonaws.com"
+    end
+
     def url(query)
       [
-        "http://search-",
-        "#{config.domain_name}-",
-        "#{config.domain_id}.",
-        "#{config.region}.",
-        "cloudsearch.amazonaws.com/",
-        "#{config.api_version}/",
-        "search?",
+        "#{url_schema}",
+        "://",
+        "#{search_domain}",
+        "#{canonical_url}",
+        '?',
         query
       ].join
     end
 
     def send_request_to_aws(query)
       url_query = url(query)
-      HTTParty.get(url_query)
+      
+      signature = if config.access_key_id && config.secret_key
+                  Rawscsi::RequestSignature.new({
+                    secret_key: config.secret_key,
+                    access_key_id: config.access_key_id,
+                    region_name: config.region,
+                    endpoint: canonical_url,
+                    query: query,
+                    method: 'GET',
+                    host: search_domain,
+                  }).build
+                else
+                  {}
+                end
+      HTTParty.get(url_query, headers: signature[:headers])
     end
+
 
     def results_container(response)
       if is_active_record


### PR DESCRIPTION
Hi. We've encountered that
1. we cannot just change domains where gem expects to see cloudsearch - we needed to point it to our mock servers for end-to-end testing
2. we cannot limit the access for indexing/searching in our CloudSearch indexes because there is no auth currently in gem - requests are not signed
so, we decided to implement this functionality.

Feel free to provide any feedback and/or suggest any improvements - this code is crude and has no test coverage yet. I'm not sure how to test the signing part in the gem tests ATM.

Thanks.

