### PR TITLE
use [0] instead of first on string

### DIFF
--- a/lib/rawscsi/request_signature.rb
+++ b/lib/rawscsi/request_signature.rb
@@ -133,7 +133,7 @@ module Rawscsi
     def canonical_headers
       @canonical_headers ||= headers.to_a.group_by(&:first).map do |name, values|
         canonical_values = values.map(&:last).map do |value|
-          value.to_s.first == '"' ? value : value.squeeze(' ')
+          value.to_s.[0]] == '"' ? value : value.squeeze(' ')
         end
         [ name.to_s.downcase, canonical_values.join(',') ]
       end.sort { |a, b| a.first <=> b.first }


### PR DESCRIPTION
In newer versions of Ruby, there's no String#first method, but from 1.9+, using the [0] substring method will work.
